### PR TITLE
Fix CLI app info

### DIFF
--- a/zephyr-mcumgr-cli/src/main.rs
+++ b/zephyr-mcumgr-cli/src/main.rs
@@ -205,7 +205,7 @@ fn cli_main() -> Result<(), CliError> {
                     let build_time = match client.os_application_info(Some("b")) {
                         Ok(val) => Some(val),
                         Err(ExecuteError::ErrorResponse(e)) => {
-                            log::debug!("Failed to fetch build time: {:?}", e);
+                            log::debug!("Failed to fetch build time: {e}");
                             None
                         }
                         Err(e) => Err(e)?,


### PR DESCRIPTION
Turns out my assumption that you can simply split the `a` app info string by whitespace is wrong; the build time string has whitespace in it.

So let's query each entry separately.