### PR TITLE
Remove temporary python stub workaround

### DIFF
--- a/mcumgr-toolkit-python/mcumgr_toolkit.pyi
+++ b/mcumgr-toolkit-python/mcumgr_toolkit.pyi
@@ -191,7 +191,7 @@ class MCUmgrClient:
         - `1234:.*:[2-3]` - Vendor ID 1234, any Product Id, Interface 2 or 3.
         """
     @staticmethod
-    def udp(host: builtins.str | ipaddress.IPv4Address | ipaddress.IPv6Address, port: builtins.int = 1337, timeout_ms: builtins.int = 1000) -> MCUmgrClient:
+    def udp(host: typing.Union[builtins.str, ipaddress.IPv4Address | ipaddress.IPv6Address], port: builtins.int = 1337, timeout_ms: builtins.int = 1000) -> MCUmgrClient:
         r"""
         Creates a new UDP-based Zephyr MCUmgr SMP client.
         

--- a/mcumgr-toolkit-python/src/lib.rs
+++ b/mcumgr-toolkit-python/src/lib.rs
@@ -119,12 +119,7 @@ impl MCUmgrClient {
     ///
     #[staticmethod]
     #[pyo3(signature = (host, port=1337, timeout_ms=::mcumgr_toolkit::DEFAULT_TIMEOUT_MS))]
-    fn udp(
-        #[gen_stub(override_type(type_repr="builtins.str | ipaddress.IPv4Address | ipaddress.IPv6Address", imports=("builtins", "ipaddress")))]
-        host: Either<&str, std::net::IpAddr>,
-        port: u16,
-        timeout_ms: u64,
-    ) -> PyResult<Self> {
+    fn udp(host: Either<&str, std::net::IpAddr>, port: u16, timeout_ms: u64) -> PyResult<Self> {
         let socketaddr = match host {
             Either::Left(addr_str) => (addr_str, port)
                 .to_socket_addrs()


### PR DESCRIPTION
With the new version of pyo3-stub-gen and its new support for IpAddress, this workaround is no longer necessary.